### PR TITLE
ユーザ登録画面の実装

### DIFF
--- a/src/src/app/login/page.tsx
+++ b/src/src/app/login/page.tsx
@@ -79,7 +79,7 @@ const LoginForm = () => {
 
           <p className="mt-3 text-center text-sm text-gray-500">
             <Link 
-              href="/signup" 
+              href="/users/register" 
               className="font-semibold leading-6 text-gray-600 hover:text-gray-500 transition-colors"
             >
               新規会員登録はこちら

--- a/src/src/app/ui/users/UserRegistrationForm.tsx
+++ b/src/src/app/ui/users/UserRegistrationForm.tsx
@@ -34,7 +34,7 @@ export const UserRegistrationForm = () => {
     setIsSubmitting(true);
 
     try {
-      await fetcher('api/register', {
+      await fetcher('api/users/register', {
         method: 'POST',
         body: JSON.stringify(formData),
       });

--- a/src/src/app/ui/users/UserRegistrationForm.tsx
+++ b/src/src/app/ui/users/UserRegistrationForm.tsx
@@ -39,6 +39,7 @@ export const UserRegistrationForm = () => {
         body: JSON.stringify(formData),
       });
 
+      alert('ユーザの登録が完了しました');
       router.push('/login');
     } catch (error) {
       console.error('ユーザ登録に失敗しました:', error);

--- a/src/src/app/ui/users/UserRegistrationForm.tsx
+++ b/src/src/app/ui/users/UserRegistrationForm.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from 'react';
+import { Button } from '../buttons/Button';
+import { TextField } from '../inputs/TextField';
+import { fetcher } from '../../../../lib/utils';
+import { useRouter } from 'next/navigation';
+
+interface UserFormData {
+  name: string;
+  password: string;
+  email: string;
+}
+
+export const UserRegistrationForm = () => {
+  const router = useRouter();
+  const [formData, setFormData] = useState<UserFormData>({
+    name: '',
+    password: '',
+    email: ''
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      await fetcher('api/register', {
+        method: 'POST',
+        body: JSON.stringify(formData),
+      });
+
+      router.push('/login');
+    } catch (error) {
+      console.error('ユーザ登録に失敗しました:', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+        <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+          <h2 className="text-center text-2xl font-bold leading-9 tracking-tight text-gray-600">
+            ユーザ登録
+          </h2>
+        </div>
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div>
+            <TextField
+              label="ユーザ名"
+              dataName="name"
+              value={formData.name}
+              onChange={handleInputChange}
+            />
+          </div>
+
+          <div>
+            <TextField
+              label="メールアドレス"
+              dataName="email"
+              type="email"
+              value={formData.email}
+              onChange={handleInputChange}
+            />
+          </div>
+
+          <div>
+            <TextField
+              label="パスワード"
+              dataName="password"
+              type="password"
+              value={formData.password}
+              onChange={handleInputChange}
+            />
+          </div>
+
+          <div>
+            <div className="mt-2">
+              <Button 
+                value={isSubmitting ? '登録中...' : '登録'} 
+                type="submit"
+                disabled={isSubmitting}
+              />
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/src/app/users/register/page.tsx
+++ b/src/src/app/users/register/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { UserRegistrationForm } from '../../ui/users/UserRegistrationForm';
+
+export default function UserRegistrationPage() {
+  return (
+    <UserRegistrationForm />
+  );
+}

--- a/src/src/middleware.ts
+++ b/src/src/middleware.ts
@@ -7,10 +7,20 @@ const getTokenFromCookie = (request: NextRequest) => {
 };
 
 export function middleware(request: NextRequest) {
-  
+  const { pathname } = request.nextUrl;
   const token = getTokenFromCookie(request);
   const isAuthenticated = !!token;
 
+  // ルートパスの処理
+  if (pathname === '/') {
+    if (isAuthenticated) {
+      return NextResponse.redirect(new URL('/books', request.url))
+    } else {
+      return NextResponse.redirect(new URL('/login', request.url))
+    }
+  }
+
+  // 保護されたルートの処理
   if (!isAuthenticated) {
     console.log("ユーザーは未認証です。ログインページにリダイレクトします。")
     return NextResponse.redirect(new URL('/login', request.url))
@@ -21,6 +31,7 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    '/',
     '/books/:path*',
     '/api/books/:path*'
   ]


### PR DESCRIPTION
# 概要
ユーザ登録画面の実装

# 修正点
- ユーザ登録画面の作成
- ユーザ登録APIとの連携
- ルートパスにアクセスした際にログイン前はログイン画面、ログイン後は本一覧画面にリダイレクトさせる

# 動作確認
## 前提条件
- apiのブランチが「bug/27-fix-user-register」であること

## 手順
### ユーザ登録ができること
- [ ] ログイン画面を開き、「新規会員登録はこちら」をクリック
- [ ] ユーザ名、メールアドレス、パスワードを入力して登録ボタンをクリック
- [ ] 登録が完了すれば、完了したことを伝えるアラートが表示されるので閉じる
- [ ] 先ほど入力した内容でログインできることを確認する

### ログイン後の状態でルートパスにアクセスすると本一覧にリダイレクトする
- [ ] ログインした状態で、「http://localhost:3000/ 」にアクセスする
- [ ] 404エラーではなく、本一覧画面が表示されていることを確認する

### ログイン前の状態でルートパスにアクセスするとログイン画面にリダイレクトする
- [ ] ログイン前かログアウトした状態で、「http://localhost:3000/ 」にアクセスする
- [ ] 404エラーではなく、ログイン画面が表示されていることを確認する

# スクリーンショット
![スクリーンショット 2025-06-15 17 36 59](https://github.com/user-attachments/assets/dbbb89b8-ed01-4127-8f91-98a0062097cc)
